### PR TITLE
Implement B3 stock info in converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ A Python application to convert between fiat currencies and cryptocurrencies, an
 - Auto-detects whether to run GUI or console
 - Menu allows choosing between converter or simulator
 
+### 📊 B3 Stocks
+- View example prices of popular B3 tickers in BRL
+- Weekly return percentages displayed
+
 ---
 
 ## 🖥️ How to Run
@@ -121,12 +125,15 @@ A Python application to convert between fiat currencies and cryptocurrencies, an
 ```bash
 python standalone.py
 ```
+The application chooses GUI or CLI automatically depending on your environment.
+Use the menu to access the currency converter, the profit simulator or the B3 stock list.
 
 ### Run Web Version
 ```bash
 python web.py
 ```
 Access: http://127.0.0.1:5000
+Navigate to `/b3` for the B3 stocks page.
 
 ### Run Tests
 ```bash

--- a/core.py
+++ b/core.py
@@ -39,3 +39,27 @@ def investment_for_weekly_profit(target: float, weekly_return_percent: float) ->
         raise ValueError("Rendimento deve ser maior que zero.")
     return target / (weekly_return_percent / 100)
 
+
+# =========================== B3 stock data ============================
+# In environments without internet access we keep a small offline table
+# with example prices (in BRL) and estimated weekly returns.  These
+# values are merely illustrative.
+B3_STOCKS = {
+    "PETR4": {"name": "Petrobras PN", "price_brl": 37.50, "weekly_return": 2.1},
+    "VALE3": {"name": "Vale ON", "price_brl": 62.00, "weekly_return": -1.2},
+    "ABEV3": {"name": "Ambev ON", "price_brl": 14.20, "weekly_return": 0.8},
+}
+
+
+def get_b3_stocks() -> dict:
+    """Return mapping of B3 tickers to info."""
+    return B3_STOCKS
+
+
+def get_b3_stock_info(ticker: str) -> dict:
+    """Return information for a B3 stock ticker."""
+    if ticker not in B3_STOCKS:
+        raise ValueError("Ticker inválido")
+    return B3_STOCKS[ticker]
+
+

--- a/standalone.py
+++ b/standalone.py
@@ -6,6 +6,7 @@ import core
 
 # Mapping of formatted currency name to code used in the interfaces
 MOEDAS = core.FORMATTED_TO_CODE
+ACAO_INFO = core.get_b3_stocks()
 
 def modo_console_conversor():
     print("Modo Conversor Console")
@@ -49,15 +50,40 @@ def modo_console_simulador():
     except ValueError:
         print("Valores inválidos.")
 
+
+def modo_console_b3():
+    print("Ações da B3")
+    tickers = list(ACAO_INFO.keys())
+    for i, tic in enumerate(tickers, start=1):
+        info = ACAO_INFO[tic]
+        print(f"{i}. {tic} - {info['name']}")
+
+    while True:
+        escolha = input(f"Selecione a ação (1-{len(tickers)}): ")
+        try:
+            idx = int(escolha) - 1
+            if 0 <= idx < len(tickers):
+                acao = ACAO_INFO[tickers[idx]]
+                print(
+                    f"Preço: R${acao['price_brl']:.2f} | Rendimento semanal: {acao['weekly_return']:.2f}%"
+                )
+                break
+        except ValueError:
+            pass
+        print("Opção inválida. Tente novamente.")
+
 def menu_console():
     print("== MENU ==")
     print("1 - Conversor de Moedas")
     print("2 - Simulador de Lucro Semanal")
+    print("3 - Ações da B3")
     escolha = input("Escolha uma opção: ")
     if escolha == "1":
         modo_console_conversor()
     elif escolha == "2":
         modo_console_simulador()
+    elif escolha == "3":
+        modo_console_b3()
     else:
         print("Opção inválida.")
 
@@ -132,6 +158,29 @@ def abrir_conversor():
     resultado_var = tk.StringVar()
     tk.Label(janela_conversor, textvariable=resultado_var, font=("Helvetica", 14)).pack(pady=10)
 
+
+def abrir_b3():
+    janela_b3 = tk.Toplevel()
+    janela_b3.title("Ações da B3")
+
+    tk.Label(janela_b3, text="Selecione a ação:").pack()
+    tickers = list(ACAO_INFO.keys())
+    combo = ttk.Combobox(janela_b3, values=tickers, state="readonly")
+    combo.current(0)
+    combo.pack()
+
+    texto_var = tk.StringVar()
+
+    def mostrar(*args):
+        info = ACAO_INFO[combo.get()]
+        texto_var.set(
+            f"Preço: R${info['price_brl']:.2f} | Rendimento semanal: {info['weekly_return']:.2f}%"
+        )
+
+    combo.bind("<<ComboboxSelected>>", mostrar)
+    mostrar()
+    tk.Label(janela_b3, textvariable=texto_var, font=("Helvetica", 12)).pack(pady=10)
+
 def menu_gui():
     janela_menu = tk.Tk()
     janela_menu.title("Menu")
@@ -139,6 +188,7 @@ def menu_gui():
     tk.Label(janela_menu, text="Escolha uma opção:", font=("Helvetica", 14)).pack(pady=20)
     tk.Button(janela_menu, text="Conversor de Moedas", command=abrir_conversor, width=30).pack(pady=10)
     tk.Button(janela_menu, text="Simulador de Lucro Semanal", command=abrir_simulador, width=30).pack(pady=10)
+    tk.Button(janela_menu, text="Ações da B3", command=abrir_b3, width=30).pack(pady=10)
 
     janela_menu.mainloop()
 

--- a/templates/b3.html
+++ b/templates/b3.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="pt-br">
+<head>
+    <meta charset="UTF-8">
+    <title>Ações da B3</title>
+    <style>
+        body { font-family: sans-serif; text-align: center; margin-top: 50px; }
+        table { margin:auto; border-collapse: collapse; }
+        th, td { border: 1px solid #ccc; padding: 8px 12px; }
+    </style>
+</head>
+<body>
+    <h1>Ações da B3</h1>
+    <table>
+        <tr><th>Empresa</th><th>Preço (BRL)</th><th>Rendimento Semanal (%)</th></tr>
+        {% for ticker, info in acoes.items() %}
+        <tr>
+            <td>{{ info.name }} ({{ ticker }})</td>
+            <td>{{ '%.2f'|format(info.price_brl) }}</td>
+            <td>{{ '%.2f'|format(info.weekly_return) }}</td>
+        </tr>
+        {% endfor %}
+    </table>
+    <a href="/">← Voltar ao Conversor</a>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -32,5 +32,6 @@
     {% if resultado %}
         <div class="resultado">{{ resultado }}</div>
     {% endif %}
+    <p><a href="/b3">Ver Ações da B3</a></p>
 </body>
 </html>

--- a/test_core.py
+++ b/test_core.py
@@ -13,6 +13,12 @@ class TestCore(unittest.TestCase):
     def test_convert_with_mocked_rate(self, mock_rate):
         self.assertEqual(core.convert(2, 'USD', 'BRL'), 10.0)
 
+    def test_get_b3_stock_info(self):
+        info = core.get_b3_stock_info('PETR4')
+        self.assertIn('price_brl', info)
+        with self.assertRaises(ValueError):
+            core.get_b3_stock_info('XXXX')
+
 if __name__ == '__main__':
     unittest.main()
 

--- a/web.py
+++ b/web.py
@@ -6,6 +6,7 @@ import core
 app = Flask(__name__)
 
 MOEDAS = core.CURRENCIES
+ACOES = core.get_b3_stocks()
 
 
 def salvar_historico(origem, destino, valor, convertido, cotacao):
@@ -30,6 +31,11 @@ def simulador():
             resultado = "Preencha os campos corretamente."
 
     return render_template("simulador.html", resultado=resultado)
+
+
+@app.route("/b3", methods=["GET"])
+def b3():
+    return render_template("b3.html", acoes=ACOES)
 
 
 


### PR DESCRIPTION
## Summary
- add static B3 stock table and helpers in core
- expose B3 data in console, GUI and Flask web app
- new HTML template for B3 screen
- extend README with instructions for running all modes
- add unit tests for B3 helpers

## Testing
- `python -m unittest`
- `python standalone.py <<'EOF'
3
1
EOF`
- `python web.py & sleep 2; curl -s http://127.0.0.1:5000/b3 | head -n 5; pkill -f web.py`

------
https://chatgpt.com/codex/tasks/task_e_6841a720ceb8832f91dd98fbb0a6430f