### PR TITLE
Implement monthly appreciation charts and launch config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,12 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python: Standalone",
+            "type": "python",
+            "request": "launch",
+            "program": "${workspaceFolder}/standalone.py",
+            "console": "integratedTerminal"
+        }
+    ]
+}

--- a/core.py
+++ b/core.py
@@ -13,6 +13,18 @@ CURRENCIES = {
 
 FORMATTED_TO_CODE = {f"{name} ({code})": code for code, name in CURRENCIES.items()}
 
+# Example monthly price history (in BRL) for the last 6 months. These are
+# illustrative offline values used when real data is unavailable.
+CURRENCY_HISTORY_BRL = {
+    "USD": [5.0, 5.1, 5.2, 5.3, 5.4, 5.45],
+    "BTC": [120000, 122000, 125000, 123000, 128000, 130000],
+    "ETH": [9000, 9200, 9100, 9400, 9500, 9600],
+    "BNB": [1500, 1520, 1550, 1540, 1580, 1600],
+    "SUI": [10, 10.5, 10.8, 10.3, 10.6, 10.9],
+    "PAXG": [9500, 9600, 9700, 9650, 9750, 9800],
+    "BRL": [1, 1, 1, 1, 1, 1],
+}
+
 
 def get_exchange_rate(origem: str, destino: str) -> float:
     """Return the exchange rate from origem to destino using AwesomeAPI."""
@@ -45,9 +57,24 @@ def investment_for_weekly_profit(target: float, weekly_return_percent: float) ->
 # with example prices (in BRL) and estimated weekly returns.  These
 # values are merely illustrative.
 B3_STOCKS = {
-    "PETR4": {"name": "Petrobras PN", "price_brl": 37.50, "weekly_return": 2.1},
-    "VALE3": {"name": "Vale ON", "price_brl": 62.00, "weekly_return": -1.2},
-    "ABEV3": {"name": "Ambev ON", "price_brl": 14.20, "weekly_return": 0.8},
+    "PETR4": {
+        "name": "Petrobras PN",
+        "price_brl": 37.50,
+        "weekly_return": 2.1,
+        "monthly": [34.0, 35.0, 36.2, 37.0, 37.5, 38.0],
+    },
+    "VALE3": {
+        "name": "Vale ON",
+        "price_brl": 62.00,
+        "weekly_return": -1.2,
+        "monthly": [60.0, 61.0, 63.0, 62.5, 62.0, 63.5],
+    },
+    "ABEV3": {
+        "name": "Ambev ON",
+        "price_brl": 14.20,
+        "weekly_return": 0.8,
+        "monthly": [13.5, 13.8, 14.0, 14.1, 14.2, 14.3],
+    },
 }
 
 
@@ -61,5 +88,30 @@ def get_b3_stock_info(ticker: str) -> dict:
     if ticker not in B3_STOCKS:
         raise ValueError("Ticker inválido")
     return B3_STOCKS[ticker]
+
+
+def _calc_appreciation(history: list[float]) -> list[float]:
+    """Return percentage change between consecutive entries."""
+    return [
+        (history[i] - history[i - 1]) / history[i - 1] * 100
+        for i in range(1, len(history))
+    ]
+
+
+def get_currency_monthly_appreciation(code: str) -> list[float]:
+    """Return monthly appreciation percentages for the given currency."""
+    hist = CURRENCY_HISTORY_BRL.get(code)
+    if not hist:
+        raise ValueError("Moeda inválida")
+    return _calc_appreciation(hist)
+
+
+def get_stock_monthly_appreciation(ticker: str) -> list[float]:
+    """Return monthly appreciation percentages for a B3 stock."""
+    info = get_b3_stock_info(ticker)
+    hist = info.get("monthly")
+    if not hist:
+        raise ValueError("Histórico indisponível")
+    return _calc_appreciation(hist)
 
 

--- a/standalone.py
+++ b/standalone.py
@@ -72,11 +72,53 @@ def modo_console_b3():
             pass
         print("Opção inválida. Tente novamente.")
 
+
+def modo_console_valorizacao_moeda():
+    import asciichartpy
+    print("Valorização mensal de moedas")
+    nomes = list(MOEDAS.keys())
+    for i, n in enumerate(nomes, 1):
+        print(f"{i}. {n}")
+    while True:
+        esc = input(f"Escolha a moeda (1-{len(nomes)}): ")
+        try:
+            idx = int(esc) - 1
+            if 0 <= idx < len(nomes):
+                code = MOEDAS[nomes[idx]]
+                dados = core.get_currency_monthly_appreciation(code)
+                print(asciichartpy.plot(dados, {'height':10}))
+                break
+        except Exception:
+            pass
+        print("Opção inválida. Tente novamente.")
+
+
+def modo_console_valorizacao_b3():
+    import asciichartpy
+    print("Valorização mensal de ações B3")
+    tickers = list(ACAO_INFO.keys())
+    for i, t in enumerate(tickers, 1):
+        print(f"{i}. {t}")
+    while True:
+        esc = input(f"Escolha a ação (1-{len(tickers)}): ")
+        try:
+            idx = int(esc) - 1
+            if 0 <= idx < len(tickers):
+                ticker = tickers[idx]
+                dados = core.get_stock_monthly_appreciation(ticker)
+                print(asciichartpy.plot(dados, {'height':10}))
+                break
+        except Exception:
+            pass
+        print("Opção inválida. Tente novamente.")
+
 def menu_console():
     print("== MENU ==")
     print("1 - Conversor de Moedas")
     print("2 - Simulador de Lucro Semanal")
     print("3 - Ações da B3")
+    print("4 - Valorização Mensal de Moedas")
+    print("5 - Valorização Mensal de Ações B3")
     escolha = input("Escolha uma opção: ")
     if escolha == "1":
         modo_console_conversor()
@@ -84,6 +126,10 @@ def menu_console():
         modo_console_simulador()
     elif escolha == "3":
         modo_console_b3()
+    elif escolha == "4":
+        modo_console_valorizacao_moeda()
+    elif escolha == "5":
+        modo_console_valorizacao_b3()
     else:
         print("Opção inválida.")
 
@@ -181,6 +227,50 @@ def abrir_b3():
     mostrar()
     tk.Label(janela_b3, textvariable=texto_var, font=("Helvetica", 12)).pack(pady=10)
 
+
+def abrir_valorizacao_moeda():
+    janela = tk.Toplevel()
+    janela.title("Valorização Mensal de Moedas")
+
+    tk.Label(janela, text="Selecione a moeda:").pack()
+    nomes = list(MOEDAS.keys())
+    combo = ttk.Combobox(janela, values=nomes, state="readonly")
+    combo.current(0)
+    combo.pack()
+
+    texto = tk.StringVar()
+
+    def mostrar(*args):
+        codigo = MOEDAS[combo.get()]
+        valores = core.get_currency_monthly_appreciation(codigo)
+        texto.set(" | ".join(f"{v:.1f}%" for v in valores))
+
+    combo.bind("<<ComboboxSelected>>", mostrar)
+    mostrar()
+    tk.Label(janela, textvariable=texto, font=("Helvetica", 12)).pack(pady=10)
+
+
+def abrir_valorizacao_b3():
+    janela = tk.Toplevel()
+    janela.title("Valorização Mensal de Ações B3")
+
+    tk.Label(janela, text="Selecione a ação:").pack()
+    tickers = list(ACAO_INFO.keys())
+    combo = ttk.Combobox(janela, values=tickers, state="readonly")
+    combo.current(0)
+    combo.pack()
+
+    texto = tk.StringVar()
+
+    def mostrar(*args):
+        ticker = combo.get()
+        valores = core.get_stock_monthly_appreciation(ticker)
+        texto.set(" | ".join(f"{v:.1f}%" for v in valores))
+
+    combo.bind("<<ComboboxSelected>>", mostrar)
+    mostrar()
+    tk.Label(janela, textvariable=texto, font=("Helvetica", 12)).pack(pady=10)
+
 def menu_gui():
     janela_menu = tk.Tk()
     janela_menu.title("Menu")
@@ -189,6 +279,8 @@ def menu_gui():
     tk.Button(janela_menu, text="Conversor de Moedas", command=abrir_conversor, width=30).pack(pady=10)
     tk.Button(janela_menu, text="Simulador de Lucro Semanal", command=abrir_simulador, width=30).pack(pady=10)
     tk.Button(janela_menu, text="Ações da B3", command=abrir_b3, width=30).pack(pady=10)
+    tk.Button(janela_menu, text="Valorização de Moedas", command=abrir_valorizacao_moeda, width=30).pack(pady=10)
+    tk.Button(janela_menu, text="Valorização de Ações B3", command=abrir_valorizacao_b3, width=30).pack(pady=10)
 
     janela_menu.mainloop()
 

--- a/templates/b3.html
+++ b/templates/b3.html
@@ -21,6 +21,6 @@
         </tr>
         {% endfor %}
     </table>
-    <a href="/">← Voltar ao Conversor</a>
+    <a href="/b3_valorizacao">Ver Valorização Mensal</a> | <a href="/">← Voltar ao Conversor</a>
 </body>
 </html>

--- a/templates/b3_val.html
+++ b/templates/b3_val.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="pt-br">
+<head>
+    <meta charset="UTF-8">
+    <title>Valorização Ações B3</title>
+    <style>
+        body { font-family: sans-serif; text-align: center; margin-top: 40px; }
+        table { margin:auto; border-collapse: collapse; }
+        th, td { border:1px solid #ccc; padding:6px 10px; }
+    </style>
+</head>
+<body>
+    <h1>Valorização Mensal de Ações B3</h1>
+    <table>
+        <tr><th>Ticker</th><th>Variações (%)</th></tr>
+        {% for tic, lista in dados.items() %}
+        <tr>
+            <td>{{ tic }}</td>
+            <td>{{ ' | '.join('%.1f'|format(x) for x in lista) }}</td>
+        </tr>
+        {% endfor %}
+    </table>
+    <a href="/">← Voltar</a>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -32,6 +32,6 @@
     {% if resultado %}
         <div class="resultado">{{ resultado }}</div>
     {% endif %}
-    <p><a href="/b3">Ver Ações da B3</a></p>
+    <p><a href="/b3">Ver Ações da B3</a> | <a href="/moedas">Valorização de Moedas</a> | <a href="/b3_valorizacao">Valorização de Ações</a></p>
 </body>
 </html>

--- a/templates/moedas.html
+++ b/templates/moedas.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="pt-br">
+<head>
+    <meta charset="UTF-8">
+    <title>Valorização de Moedas</title>
+    <style>
+        body { font-family: sans-serif; text-align: center; margin-top: 40px; }
+        table { margin:auto; border-collapse: collapse; }
+        th, td { border:1px solid #ccc; padding:6px 10px; }
+    </style>
+</head>
+<body>
+    <h1>Valorização Mensal de Moedas</h1>
+    <table>
+        <tr><th>Moeda</th><th>Variações (%)</th></tr>
+        {% for cod, lista in dados.items() %}
+        <tr>
+            <td>{{ cod }}</td>
+            <td>{{ ' | '.join('%.1f'|format(x) for x in lista) }}</td>
+        </tr>
+        {% endfor %}
+    </table>
+    <a href="/">← Voltar</a>
+</body>
+</html>

--- a/test_core.py
+++ b/test_core.py
@@ -19,6 +19,18 @@ class TestCore(unittest.TestCase):
         with self.assertRaises(ValueError):
             core.get_b3_stock_info('XXXX')
 
+    def test_currency_monthly_appreciation(self):
+        vals = core.get_currency_monthly_appreciation('USD')
+        self.assertEqual(len(vals), len(core.CURRENCY_HISTORY_BRL['USD']) - 1)
+        with self.assertRaises(ValueError):
+            core.get_currency_monthly_appreciation('XYZ')
+
+    def test_stock_monthly_appreciation(self):
+        vals = core.get_stock_monthly_appreciation('PETR4')
+        self.assertEqual(len(vals), len(core.B3_STOCKS['PETR4']['monthly']) - 1)
+        with self.assertRaises(ValueError):
+            core.get_stock_monthly_appreciation('XXXX')
+
 if __name__ == '__main__':
     unittest.main()
 

--- a/web.py
+++ b/web.py
@@ -38,6 +38,24 @@ def b3():
     return render_template("b3.html", acoes=ACOES)
 
 
+@app.route("/moedas")
+def moedas():
+    dados = {
+        code: core.get_currency_monthly_appreciation(code)
+        for code in MOEDAS.keys()
+    }
+    return render_template("moedas.html", dados=dados)
+
+
+@app.route("/b3_valorizacao")
+def b3_valorizacao():
+    dados = {
+        t: core.get_stock_monthly_appreciation(t)
+        for t in ACOES.keys()
+    }
+    return render_template("b3_val.html", dados=dados)
+
+
 
 @app.route("/", methods=["GET", "POST"])
 def index():


### PR DESCRIPTION
## Summary
- add offline monthly price history and accessor functions in `core.py`
- expose appreciation charts in console UI using asciichartpy
- add GUI windows and web routes for monthly appreciation
- include new HTML templates for valuation tables
- update unit tests
- create VS Code `launch.json`

## Testing
- `python -m unittest -v`

------
https://chatgpt.com/codex/tasks/task_e_6841b142e060832f8e6ca88f99135833