### PR TITLE
Add Windows build support

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,14 @@ Navigate to `/b3` for the B3 stocks page.
 python -m unittest
 ```
 
+### Build Windows Executable
+Use [PyInstaller](https://pyinstaller.org/) to bundle the application into a
+single Windows binary. From a Windows command prompt run:
+```cmd
+build_windows.bat
+```
+The generated `DollarConverter.exe` will be available in the `dist` folder.
+
 ### Deployment
 The Flask web app requires a Python server and therefore cannot run directly on
 GitHub Pages. To make it accessible online you can deploy it on services such as

--- a/build_windows.bat
+++ b/build_windows.bat
@@ -1,0 +1,6 @@
+@echo off
+REM Build DollarConverter as a standalone Windows executable
+REM Ensure PyInstaller is installed
+py -m pip install --upgrade pyinstaller
+py -m PyInstaller --name DollarConverter --onefile standalone.py
+


### PR DESCRIPTION
## Summary
- add `build_windows.bat` to compile a Windows executable via PyInstaller
- document Windows build instructions in README

## Testing
- `python -m unittest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841be229934832f8f1502513471a6d5