### PR TITLE
Add API unavailability error handling

### DIFF
--- a/core.py
+++ b/core.py
@@ -29,9 +29,12 @@ CURRENCY_HISTORY_BRL = {
 def get_exchange_rate(origem: str, destino: str) -> float:
     """Return the exchange rate from origem to destino using AwesomeAPI."""
     url = f"https://economia.awesomeapi.com.br/json/last/{origem}-{destino}"
-    response = requests.get(url, timeout=10)
-    response.raise_for_status()
-    data = response.json()
+    try:
+        response = requests.get(url, timeout=10)
+        response.raise_for_status()
+        data = response.json()
+    except requests.RequestException as exc:
+        raise ConnectionError("API de cotações indisponível") from exc
     key = f"{origem}{destino}"
     if key not in data:
         raise ValueError("Par de moedas inválido")

--- a/standalone.py
+++ b/standalone.py
@@ -32,6 +32,8 @@ def modo_console_conversor():
         valor = float(valor)
         convertido = core.convert(valor, origem, destino)
         print(f"Resultado: {convertido:.4f} {destino}")
+    except ConnectionError:
+        print("Erro: API de cotações indisponível")
     except Exception as e:
         print(f"Erro: {e}")
 
@@ -175,6 +177,8 @@ def abrir_conversor():
             resultado_var.set(
                 f"{valor:.4f} {origem} = {convertido:.4f} {destino}"
             )
+        except ConnectionError:
+            messagebox.showerror("Erro", "API de cotações indisponível")
         except ValueError:
             messagebox.showwarning("Aviso", "Digite um valor válido.")
 

--- a/test_core.py
+++ b/test_core.py
@@ -31,6 +31,11 @@ class TestCore(unittest.TestCase):
         with self.assertRaises(ValueError):
             core.get_stock_monthly_appreciation('XXXX')
 
+    @patch('core.requests.get', side_effect=core.requests.RequestException)
+    def test_get_exchange_rate_api_down(self, mock_get):
+        with self.assertRaises(ConnectionError):
+            core.get_exchange_rate('USD', 'BRL')
+
 if __name__ == '__main__':
     unittest.main()
 

--- a/web.py
+++ b/web.py
@@ -69,6 +69,8 @@ def index():
             convertido = core.convert(valor_float, de, para)
             resultado = f"{valor_float:.4f} {de} = {convertido:.4f} {para}"
             salvar_historico(de, para, valor_float, convertido, core.get_exchange_rate(de, para))
+        except ConnectionError:
+            resultado = "API de cotações indisponível."
         except Exception:
             resultado = "Valor inválido."
 


### PR DESCRIPTION
## Summary
- handle RequestException in `core.get_exchange_rate`
- show user-friendly API error message in console, GUI and web
- test API unavailability handling

## Testing
- `python -m unittest`

------
https://chatgpt.com/codex/tasks/task_e_6841c80b4cdc832fb27e1bd4746f5649