### PR TITLE
Implement monitoring mode

### DIFF
--- a/core.py
+++ b/core.py
@@ -244,3 +244,32 @@ def get_stock_monthly_appreciation(ticker: str) -> list[float]:
     return _calc_appreciation(hist)
 
 
+def get_currency_price_brl(code: str) -> float:
+    """Return the latest price of a currency in BRL.
+
+    Falls back to the last offline value if the API is unavailable.
+    """
+    if code == "BRL":
+        return 1.0
+    try:
+        return get_exchange_rate(code, "BRL")
+    except Exception:
+        hist = CURRENCY_HISTORY_BRL.get(code)
+        if not hist:
+            raise
+        return hist[-1]
+
+
+def get_all_currency_prices_brl() -> dict:
+    """Return current BRL prices for all known currencies."""
+    return {c: get_currency_price_brl(c) for c in CURRENCIES.keys()}
+
+
+def gather_monitor_data() -> dict:
+    """Return data used by the monitoring interfaces."""
+    return {
+        "currencies": get_all_currency_prices_brl(),
+        "stocks": {t: info["price_brl"] for t, info in B3_STOCKS.items()},
+    }
+
+

--- a/standalone.py
+++ b/standalone.py
@@ -114,26 +114,62 @@ def modo_console_valorizacao_b3():
             pass
         print("Opção inválida. Tente novamente.")
 
+
+def modo_console_monitor():
+    """Display prices updating every 5 minutes."""
+    import time
+    import asciichartpy
+    try:
+        while True:
+            os.system("cls" if os.name == "nt" else "clear")
+            print(
+                "Monitor de Cotações - atualiza a cada 5 minutos (Ctrl+C para sair)\n"
+            )
+            dados = core.gather_monitor_data()
+            for cod, preco in dados["currencies"].items():
+                hist = core.CURRENCY_HISTORY_BRL.get(cod, [])
+                graf = asciichartpy.plot(hist[-6:], {"height": 3}) if hist else ""
+                print(f"{cod}: R${preco:.2f}")
+                if graf:
+                    print(graf)
+            print("\n-- Ações B3 --")
+            for tic, preco in dados["stocks"].items():
+                hist = core.B3_STOCKS[tic].get("monthly", [])
+                graf = asciichartpy.plot(hist[-6:], {"height": 3}) if hist else ""
+                print(f"{tic}: R${preco:.2f}")
+                if graf:
+                    print(graf)
+            time.sleep(300)
+    except KeyboardInterrupt:
+        pass
+
 def menu_console():
-    print("== MENU ==")
-    print("1 - Conversor de Moedas")
-    print("2 - Simulador de Lucro Semanal")
-    print("3 - Ações da B3")
-    print("4 - Valorização Mensal de Moedas")
-    print("5 - Valorização Mensal de Ações B3")
-    escolha = input("Escolha uma opção: ")
-    if escolha == "1":
-        modo_console_conversor()
-    elif escolha == "2":
-        modo_console_simulador()
-    elif escolha == "3":
-        modo_console_b3()
-    elif escolha == "4":
-        modo_console_valorizacao_moeda()
-    elif escolha == "5":
-        modo_console_valorizacao_b3()
-    else:
-        print("Opção inválida.")
+    while True:
+        print("== MENU ==")
+        print("1 - Conversor de Moedas")
+        print("2 - Simulador de Lucro Semanal")
+        print("3 - Ações da B3")
+        print("4 - Valorização Mensal de Moedas")
+        print("5 - Valorização Mensal de Ações B3")
+        print("6 - Monitor de Cotações (5 min)")
+        print("0 - Sair")
+        escolha = input("Escolha uma opção: ")
+        if escolha == "1":
+            modo_console_conversor()
+        elif escolha == "2":
+            modo_console_simulador()
+        elif escolha == "3":
+            modo_console_b3()
+        elif escolha == "4":
+            modo_console_valorizacao_moeda()
+        elif escolha == "5":
+            modo_console_valorizacao_b3()
+        elif escolha == "6":
+            modo_console_monitor()
+        elif escolha == "0":
+            break
+        else:
+            print("Opção inválida.")
 
 def abrir_simulador():
     def simular():
@@ -275,6 +311,35 @@ def abrir_valorizacao_b3():
     mostrar()
     tk.Label(janela, textvariable=texto, font=("Helvetica", 12)).pack(pady=10)
 
+
+def abrir_monitor_gui():
+    janela = tk.Toplevel()
+    janela.title("Monitor de Cotações")
+
+    frames = {}
+
+    tk.Label(janela, text="Moedas (BRL)", font=("Helvetica", 12)).pack()
+    for cod in core.CURRENCIES.keys():
+        var = tk.StringVar()
+        tk.Label(janela, textvariable=var).pack()
+        frames[cod] = var
+
+    tk.Label(janela, text="Ações B3", font=("Helvetica", 12)).pack(pady=(10, 0))
+    for tic in core.B3_STOCKS.keys():
+        var = tk.StringVar()
+        tk.Label(janela, textvariable=var).pack()
+        frames[tic] = var
+
+    def atualizar():
+        info = core.gather_monitor_data()
+        for cod, preco in info["currencies"].items():
+            frames[cod].set(f"{cod}: R${preco:.2f}")
+        for tic, preco in info["stocks"].items():
+            frames[tic].set(f"{tic}: R${preco:.2f}")
+        janela.after(300000, atualizar)
+
+    atualizar()
+
 def menu_gui():
     janela_menu = tk.Tk()
     janela_menu.title("Menu")
@@ -285,6 +350,8 @@ def menu_gui():
     tk.Button(janela_menu, text="Ações da B3", command=abrir_b3, width=30).pack(pady=10)
     tk.Button(janela_menu, text="Valorização de Moedas", command=abrir_valorizacao_moeda, width=30).pack(pady=10)
     tk.Button(janela_menu, text="Valorização de Ações B3", command=abrir_valorizacao_b3, width=30).pack(pady=10)
+    tk.Button(janela_menu, text="Monitor de Cotações (5 min)", command=abrir_monitor_gui, width=30).pack(pady=10)
+    tk.Button(janela_menu, text="Sair", command=janela_menu.destroy, width=30).pack(pady=10)
 
     janela_menu.mainloop()
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -32,6 +32,6 @@
     {% if resultado %}
         <div class="resultado">{{ resultado }}</div>
     {% endif %}
-    <p><a href="/b3">Ver Ações da B3</a> | <a href="/moedas">Valorização de Moedas</a> | <a href="/b3_valorizacao">Valorização de Ações</a></p>
+    <p><a href="/b3">Ver Ações da B3</a> | <a href="/moedas">Valorização de Moedas</a> | <a href="/b3_valorizacao">Valorização de Ações</a> | <a href="/monitor">Monitor (5 min)</a></p>
 </body>
 </html>

--- a/templates/monitor.html
+++ b/templates/monitor.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="pt-br">
+<head>
+    <meta charset="UTF-8">
+    <title>Monitor de Cotações</title>
+    <meta http-equiv="refresh" content="300">
+    <style>
+        body { font-family: sans-serif; text-align: center; margin-top: 40px; }
+        table { margin:auto; border-collapse: collapse; }
+        th, td { border:1px solid #ccc; padding:6px 10px; }
+    </style>
+</head>
+<body>
+    <h1>Monitor de Cotações (atualiza a cada 5 min)</h1>
+    <h2>Moedas (BRL)</h2>
+    <table>
+        <tr><th>Moeda</th><th>Preço</th></tr>
+        {% for cod, preco in dados.currencies.items() %}
+        <tr><td>{{ cod }}</td><td>{{ '%.2f'|format(preco) }}</td></tr>
+        {% endfor %}
+    </table>
+    <h2>Ações B3</h2>
+    <table>
+        <tr><th>Ticker</th><th>Preço (BRL)</th></tr>
+        {% for tic, preco in dados.stocks.items() %}
+        <tr><td>{{ tic }}</td><td>{{ '%.2f'|format(preco) }}</td></tr>
+        {% endfor %}
+    </table>
+    <a href="/">← Voltar</a>
+</body>
+</html>

--- a/web.py
+++ b/web.py
@@ -56,6 +56,12 @@ def b3_valorizacao():
     return render_template("b3_val.html", dados=dados)
 
 
+@app.route("/monitor")
+def monitor():
+    dados = core.gather_monitor_data()
+    return render_template("monitor.html", dados=dados)
+
+
 
 @app.route("/", methods=["GET", "POST"])
 def index():


### PR DESCRIPTION
## Summary
- add functions in core for price fetching and monitoring
- improve console menu and add 5-minute monitoring loop
- add monitoring window in GUI menu
- add `/monitor` page with auto-refresh
- link monitor from index page

## Testing
- `pip install -r requirements.txt`
- `python -m unittest`


------
https://chatgpt.com/codex/tasks/task_e_6841ec539bcc832fbec2f374f0dfd429