### PR TITLE
Implement fallback conversion via USD

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Aplicativo Python que permite a conversão entre moedas tradicionais e criptomoe
   - Sui (SUI)
   - Pax Gold (PAXG)
 - Utiliza cotações em tempo real via [AwesomeAPI](https://docs.awesomeapi.com.br/api-de-moedas)
+- Conversão para BRL usa USD como intermediário quando necessário
 
 ### 📈 Simulador de Lucro Semanal
 - Calcula quanto investir para atingir uma meta semanal de lucro
@@ -93,6 +94,7 @@ A Python application to convert between fiat currencies and cryptocurrencies, an
   - Sui (SUI)
   - Pax Gold (PAXG)
 - Uses real-time exchange rates from [AwesomeAPI](https://docs.awesomeapi.com.br/api-de-moedas)
+- Conversions to BRL automatically fallback through USD when a direct pair is unavailable
 
 ### 📈 Weekly Profit Simulator
 - Calculates required investment for a target weekly profit

--- a/test_core.py
+++ b/test_core.py
@@ -13,6 +13,40 @@ class TestCore(unittest.TestCase):
     def test_convert_with_mocked_rate(self, mock_rate):
         self.assertEqual(core.convert(2, 'USD', 'BRL'), 10.0)
 
+    def test_convert_to_brl_via_usd(self):
+        seq = [
+            ValueError('Par de moedas inválido'),
+            300.0,  # BNB->USD
+            5.0     # USD->BRL
+        ]
+
+        def side_effect(origem, destino):
+            res = seq.pop(0)
+            if isinstance(res, Exception):
+                raise res
+            return res
+
+        with patch('core.get_exchange_rate', side_effect=side_effect):
+            result = core.convert(1, 'BNB', 'BRL')
+            self.assertEqual(result, 1500.0)
+
+    def test_get_currency_price_brl_fallback(self):
+        seq = [
+            ValueError('Par de moedas inválido'),
+            200.0,  # ETH->USD
+            5.0     # USD->BRL
+        ]
+
+        def side_effect(origem, destino):
+            res = seq.pop(0)
+            if isinstance(res, Exception):
+                raise res
+            return res
+
+        with patch('core.get_exchange_rate', side_effect=side_effect):
+            price = core.get_currency_price_brl('ETH')
+            self.assertEqual(price, 1000.0)
+
     def test_get_b3_stock_info(self):
         info = core.get_b3_stock_info('PETR4')
         self.assertIn('price_brl', info)


### PR DESCRIPTION
## Summary
- add USD fallback when converting to BRL
- fetch BRL prices using conversion helper
- document conversion fallback in README
- cover BRL fallback logic with unit tests

## Testing
- `python -m unittest`

------
https://chatgpt.com/codex/tasks/task_e_6867defaa170832f99e6e9e677bfc396