### PR TITLE
Improve B3 data handling with API fallback

### DIFF
--- a/standalone.py
+++ b/standalone.py
@@ -66,8 +66,13 @@ def modo_console_b3():
             idx = int(escolha) - 1
             if 0 <= idx < len(tickers):
                 acao = ACAO_INFO[tickers[idx]]
+                try:
+                    preco = core.get_b3_stock_price_brl(tickers[idx])
+                except ConnectionError:
+                    preco = acao['price_brl']
+                    print('Falha ao atualizar preço online, exibindo valor offline.')
                 print(
-                    f"Preço: R${acao['price_brl']:.2f} | Rendimento semanal: {acao['weekly_return']:.2f}%"
+                    f"Preço: R${preco:.2f} | Rendimento semanal: {acao['weekly_return']:.2f}%"
                 )
                 break
         except ValueError:

--- a/web.py
+++ b/web.py
@@ -11,8 +11,14 @@ ACOES = core.get_b3_stocks()
 
 def salvar_historico(origem, destino, valor, convertido, cotacao):
     data = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-    with open("historico.txt", "a", encoding="utf-8") as f:
-        f.write(f"[{data}] {valor} {origem} -> {convertido:.2f} {destino} (cotação: {cotacao})\n")
+    try:
+        with open("historico.txt", "a", encoding="utf-8") as f:
+            f.write(
+                f"[{data}] {valor} {origem} -> {convertido:.2f} {destino} (cotação: {cotacao})\n"
+            )
+    except OSError:
+        # Falha ao salvar o histórico não deve interromper a aplicação
+        pass
 
 @app.route("/simulador", methods=["GET", "POST"])
 def simulador():
@@ -35,7 +41,14 @@ def simulador():
 
 @app.route("/b3", methods=["GET"])
 def b3():
-    return render_template("b3.html", acoes=ACOES)
+    dados = {}
+    for tic, info in ACOES.items():
+        try:
+            preco = core.get_b3_stock_price_brl(tic)
+        except ConnectionError:
+            preco = info["price_brl"]
+        dados[tic] = {**info, "price_brl": preco}
+    return render_template("b3.html", acoes=dados)
 
 
 @app.route("/moedas")


### PR DESCRIPTION
## Summary
- fetch B3 stock prices from brapi.dev when online
- provide fallback to offline prices
- handle history write failures gracefully in web app
- show online B3 prices on console and web
- update tests for new B3 functions

## Testing
- `pip install -r requirements.txt`
- `python -m unittest`

------
https://chatgpt.com/codex/tasks/task_e_686843b7bf3c832f836d23d258f1c6fc