### PR TITLE
Fix blank screen on GitHub Pages deploy

### DIFF
--- a/app/web/flutter_bootstrap.js
+++ b/app/web/flutter_bootstrap.js
@@ -1,0 +1,10 @@
+// Custom bootstrap: forces CanvasKit to load from the locally bundled
+// "canvaskit/" assets instead of the default gstatic.com CDN, so the
+// app doesn't depend on third-party CDN access.
+{{flutter_js}}
+{{flutter_build_config}}
+_flutter.loader.load({
+  config: {
+    canvasKitBaseUrl: "canvaskit/",
+  },
+});

--- a/app/web/index.html
+++ b/app/web/index.html
@@ -34,26 +34,14 @@
 </head>
 <body>
   <!--
-    Custom bootstrap: forces CanvasKit to load from the locally bundled
-    "canvaskit/" assets instead of the default gstatic.com CDN, so the
-    app works fully offline / without third-party CDN access (relevant
-    for GitHub Pages hosting and restricted network environments).
+    "flutter_bootstrap.js" is customized (see web/flutter_bootstrap.js)
+    to load CanvasKit from the locally bundled "canvaskit/" assets
+    instead of the default gstatic.com CDN, so the app doesn't depend
+    on third-party CDN access.
 
     For more details:
     * https://docs.flutter.dev/platform-integration/web/initialization
   -->
-  <script src="flutter.js" defer></script>
-  <script>
-    window.addEventListener('load', function () {
-      _flutter.loader.load({
-        onEntrypointLoaded: async function (engineInitializer) {
-          const appRunner = await engineInitializer.initializeEngine({
-            canvasKitBaseUrl: "canvaskit/",
-          });
-          appRunner.runApp();
-        },
-      });
-    });
-  </script>
+  <script src="flutter_bootstrap.js" async></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- The app deployed to GitHub Pages showed a blank white page. Root cause: the custom `index.html` bootstrap script (added to force CanvasKit to load from local assets instead of the gstatic.com CDN) dropped the `_flutter.buildConfig` assignment that Flutter's loader requires, so `FlutterLoader.load` threw silently.
- Fixed by using Flutter's supported customization point — a `web/flutter_bootstrap.js` with the `{{flutter_js}}`/`{{flutter_build_config}}` placeholders — which keeps the generated build config intact while still pointing `canvasKitBaseUrl` at the bundled `canvaskit/` assets.

## Test plan
- [x] Verified the built `flutter_bootstrap.js` now contains both the `_flutter.buildConfig = {...}` assignment and the `config: { canvasKitBaseUrl: "canvaskit/" }` call
- [ ] Confirm the live GitHub Pages site renders the app after this merges and the deploy workflow runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)