### PR TITLE
Add dedicated Índices and Ações S&P 500 screens

### DIFF
--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -4,7 +4,9 @@ import 'screens/appreciation_screen.dart';
 import 'screens/b3_screen.dart';
 import 'screens/converter_screen.dart';
 import 'screens/dashboard_screen.dart';
+import 'screens/indices_screen.dart';
 import 'screens/simulator_screen.dart';
+import 'screens/sp500_screen.dart';
 
 void main() {
   runApp(const InvestWatchApp());
@@ -38,13 +40,15 @@ class HomeShell extends StatefulWidget {
 class _HomeShellState extends State<HomeShell> {
   int _index = 0;
 
-  static const _titles = ['Monitor', 'Conversor', 'Simulador', 'Ações B3', 'Valorização'];
+  static const _titles = ['Monitor', 'Conversor', 'Simulador', 'Ações B3', 'Ações S&P 500', 'Índices', 'Valorização'];
 
   static const _screens = [
     DashboardScreen(),
     ConverterScreen(),
     SimulatorScreen(),
     B3Screen(),
+    SP500Screen(),
+    IndicesScreen(),
     AppreciationScreen(),
   ];
 
@@ -57,6 +61,8 @@ class _HomeShellState extends State<HomeShell> {
       NavigationDestination(icon: Icon(Icons.currency_exchange), label: 'Conversor'),
       NavigationDestination(icon: Icon(Icons.calculate_outlined), selectedIcon: Icon(Icons.calculate), label: 'Simulador'),
       NavigationDestination(icon: Icon(Icons.show_chart), label: 'Ações B3'),
+      NavigationDestination(icon: Icon(Icons.flag), label: 'S&P 500'),
+      NavigationDestination(icon: Icon(Icons.public), label: 'Índices'),
       NavigationDestination(icon: Icon(Icons.bar_chart), label: 'Valorização'),
     ];
 

--- a/app/lib/models/market_data.dart
+++ b/app/lib/models/market_data.dart
@@ -5,14 +5,14 @@
 class StockInfo {
   final String ticker;
   final String name;
-  final double priceBrl;
+  final double price;
   final double weeklyReturn;
   final List<double> monthly;
 
   const StockInfo({
     required this.ticker,
     required this.name,
-    required this.priceBrl,
+    required this.price,
     required this.weeklyReturn,
     required this.monthly,
   });
@@ -44,30 +44,51 @@ const Map<String, List<double>> currencyHistoryBrl = {
 /// Default B3 tickers with illustrative offline data (in BRL), used as
 /// the default watchlist and as fallback when brapi.dev is unreachable.
 final Map<String, StockInfo> b3Stocks = {
-  'PETR4': const StockInfo(ticker: 'PETR4', name: 'Petrobras PN', priceBrl: 37.50, weeklyReturn: 2.1, monthly: [34.0, 35.0, 36.2, 37.0, 37.5, 38.0]),
-  'VALE3': const StockInfo(ticker: 'VALE3', name: 'Vale ON', priceBrl: 62.00, weeklyReturn: -1.2, monthly: [60.0, 61.0, 63.0, 62.5, 62.0, 63.5]),
-  'ABEV3': const StockInfo(ticker: 'ABEV3', name: 'Ambev ON', priceBrl: 14.20, weeklyReturn: 0.8, monthly: [13.5, 13.8, 14.0, 14.1, 14.2, 14.3]),
-  'KNCR11': const StockInfo(ticker: 'KNCR11', name: 'Kinea Rendimentos', priceBrl: 115.00, weeklyReturn: 0.5, monthly: [110, 111, 112, 113, 114, 115]),
-  'ITUB4': const StockInfo(ticker: 'ITUB4', name: 'Itaú Unibanco PN', priceBrl: 30.00, weeklyReturn: 1.2, monthly: [27, 28, 29, 29.5, 29.8, 30]),
-  'BBDC4': const StockInfo(ticker: 'BBDC4', name: 'Bradesco PN', priceBrl: 17.00, weeklyReturn: 1.1, monthly: [15.5, 16, 16.2, 16.7, 16.9, 17]),
-  'BBAS3': const StockInfo(ticker: 'BBAS3', name: 'Banco do Brasil ON', priceBrl: 48.00, weeklyReturn: 1.8, monthly: [45, 46, 47, 47.5, 48, 48.5]),
-  'WEGE3': const StockInfo(ticker: 'WEGE3', name: 'WEG ON', priceBrl: 37.00, weeklyReturn: 1.5, monthly: [33, 34, 35, 36, 36.5, 37]),
-  'MGLU3': const StockInfo(ticker: 'MGLU3', name: 'Magazine Luiza ON', priceBrl: 3.20, weeklyReturn: 2.5, monthly: [2.5, 2.6, 2.8, 3.0, 3.1, 3.2]),
-  'B3SA3': const StockInfo(ticker: 'B3SA3', name: 'B3 ON', priceBrl: 13.20, weeklyReturn: 1.0, monthly: [12, 12.3, 12.7, 12.9, 13.1, 13.2]),
-  'LREN3': const StockInfo(ticker: 'LREN3', name: 'Lojas Renner ON', priceBrl: 21.00, weeklyReturn: 1.4, monthly: [19, 19.8, 20.2, 20.7, 20.9, 21]),
-  'SUZB3': const StockInfo(ticker: 'SUZB3', name: 'Suzano ON', priceBrl: 55.00, weeklyReturn: 1.3, monthly: [50, 51, 52.5, 53, 54, 55]),
-  'GGBR4': const StockInfo(ticker: 'GGBR4', name: 'Gerdau PN', priceBrl: 15.00, weeklyReturn: 1.2, monthly: [13.5, 14, 14.2, 14.5, 14.8, 15]),
-  'USIM5': const StockInfo(ticker: 'USIM5', name: 'Usiminas PNA', priceBrl: 7.50, weeklyReturn: 1.1, monthly: [6.5, 6.8, 7, 7.2, 7.4, 7.5]),
-  'CSNA3': const StockInfo(ticker: 'CSNA3', name: 'CSN ON', priceBrl: 18.00, weeklyReturn: 1.5, monthly: [16, 16.5, 17, 17.5, 17.8, 18]),
-  'JBS3': const StockInfo(ticker: 'JBS3', name: 'JBS ON', priceBrl: 33.00, weeklyReturn: 1.2, monthly: [30, 30.8, 31.5, 32, 32.5, 33]),
-  'LWSA3': const StockInfo(ticker: 'LWSA3', name: 'LWSA ON', priceBrl: 5.00, weeklyReturn: 1.3, monthly: [4.2, 4.4, 4.6, 4.7, 4.9, 5.0]),
-  'PETZ3': const StockInfo(ticker: 'PETZ3', name: 'Petz ON', priceBrl: 6.30, weeklyReturn: 0.9, monthly: [5.5, 5.7, 5.8, 6.0, 6.2, 6.3]),
-  'YDUQ3': const StockInfo(ticker: 'YDUQ3', name: 'Yduqs ON', priceBrl: 18.00, weeklyReturn: 1.7, monthly: [16, 16.5, 17, 17.5, 17.8, 18]),
-  'SLCE3': const StockInfo(ticker: 'SLCE3', name: 'SLC Agrícola ON', priceBrl: 41.00, weeklyReturn: 1.4, monthly: [37, 38, 39, 39.5, 40, 41]),
-  'PRIO3': const StockInfo(ticker: 'PRIO3', name: 'PRIO ON', priceBrl: 40.00, weeklyReturn: 2.2, monthly: [34, 36, 37, 38, 39, 40]),
-  'HAPV3': const StockInfo(ticker: 'HAPV3', name: 'Hapvida ON', priceBrl: 7.00, weeklyReturn: 1.6, monthly: [5.8, 6.2, 6.5, 6.8, 6.9, 7]),
-  'EGIE3': const StockInfo(ticker: 'EGIE3', name: 'Engie Brasil ON', priceBrl: 43.00, weeklyReturn: 0.8, monthly: [41, 41.5, 42, 42.5, 42.8, 43]),
-  'NTCO3': const StockInfo(ticker: 'NTCO3', name: 'Natura ON', priceBrl: 15.00, weeklyReturn: 1.5, monthly: [13, 13.5, 14, 14.5, 14.8, 15]),
+  'PETR4': const StockInfo(ticker: 'PETR4', name: 'Petrobras PN', price: 37.50, weeklyReturn: 2.1, monthly: [34.0, 35.0, 36.2, 37.0, 37.5, 38.0]),
+  'VALE3': const StockInfo(ticker: 'VALE3', name: 'Vale ON', price: 62.00, weeklyReturn: -1.2, monthly: [60.0, 61.0, 63.0, 62.5, 62.0, 63.5]),
+  'ABEV3': const StockInfo(ticker: 'ABEV3', name: 'Ambev ON', price: 14.20, weeklyReturn: 0.8, monthly: [13.5, 13.8, 14.0, 14.1, 14.2, 14.3]),
+  'KNCR11': const StockInfo(ticker: 'KNCR11', name: 'Kinea Rendimentos', price: 115.00, weeklyReturn: 0.5, monthly: [110, 111, 112, 113, 114, 115]),
+  'ITUB4': const StockInfo(ticker: 'ITUB4', name: 'Itaú Unibanco PN', price: 30.00, weeklyReturn: 1.2, monthly: [27, 28, 29, 29.5, 29.8, 30]),
+  'BBDC4': const StockInfo(ticker: 'BBDC4', name: 'Bradesco PN', price: 17.00, weeklyReturn: 1.1, monthly: [15.5, 16, 16.2, 16.7, 16.9, 17]),
+  'BBAS3': const StockInfo(ticker: 'BBAS3', name: 'Banco do Brasil ON', price: 48.00, weeklyReturn: 1.8, monthly: [45, 46, 47, 47.5, 48, 48.5]),
+  'WEGE3': const StockInfo(ticker: 'WEGE3', name: 'WEG ON', price: 37.00, weeklyReturn: 1.5, monthly: [33, 34, 35, 36, 36.5, 37]),
+  'MGLU3': const StockInfo(ticker: 'MGLU3', name: 'Magazine Luiza ON', price: 3.20, weeklyReturn: 2.5, monthly: [2.5, 2.6, 2.8, 3.0, 3.1, 3.2]),
+  'B3SA3': const StockInfo(ticker: 'B3SA3', name: 'B3 ON', price: 13.20, weeklyReturn: 1.0, monthly: [12, 12.3, 12.7, 12.9, 13.1, 13.2]),
+  'LREN3': const StockInfo(ticker: 'LREN3', name: 'Lojas Renner ON', price: 21.00, weeklyReturn: 1.4, monthly: [19, 19.8, 20.2, 20.7, 20.9, 21]),
+  'SUZB3': const StockInfo(ticker: 'SUZB3', name: 'Suzano ON', price: 55.00, weeklyReturn: 1.3, monthly: [50, 51, 52.5, 53, 54, 55]),
+  'GGBR4': const StockInfo(ticker: 'GGBR4', name: 'Gerdau PN', price: 15.00, weeklyReturn: 1.2, monthly: [13.5, 14, 14.2, 14.5, 14.8, 15]),
+  'USIM5': const StockInfo(ticker: 'USIM5', name: 'Usiminas PNA', price: 7.50, weeklyReturn: 1.1, monthly: [6.5, 6.8, 7, 7.2, 7.4, 7.5]),
+  'CSNA3': const StockInfo(ticker: 'CSNA3', name: 'CSN ON', price: 18.00, weeklyReturn: 1.5, monthly: [16, 16.5, 17, 17.5, 17.8, 18]),
+  'JBS3': const StockInfo(ticker: 'JBS3', name: 'JBS ON', price: 33.00, weeklyReturn: 1.2, monthly: [30, 30.8, 31.5, 32, 32.5, 33]),
+  'LWSA3': const StockInfo(ticker: 'LWSA3', name: 'LWSA ON', price: 5.00, weeklyReturn: 1.3, monthly: [4.2, 4.4, 4.6, 4.7, 4.9, 5.0]),
+  'PETZ3': const StockInfo(ticker: 'PETZ3', name: 'Petz ON', price: 6.30, weeklyReturn: 0.9, monthly: [5.5, 5.7, 5.8, 6.0, 6.2, 6.3]),
+  'YDUQ3': const StockInfo(ticker: 'YDUQ3', name: 'Yduqs ON', price: 18.00, weeklyReturn: 1.7, monthly: [16, 16.5, 17, 17.5, 17.8, 18]),
+  'SLCE3': const StockInfo(ticker: 'SLCE3', name: 'SLC Agrícola ON', price: 41.00, weeklyReturn: 1.4, monthly: [37, 38, 39, 39.5, 40, 41]),
+  'PRIO3': const StockInfo(ticker: 'PRIO3', name: 'PRIO ON', price: 40.00, weeklyReturn: 2.2, monthly: [34, 36, 37, 38, 39, 40]),
+  'HAPV3': const StockInfo(ticker: 'HAPV3', name: 'Hapvida ON', price: 7.00, weeklyReturn: 1.6, monthly: [5.8, 6.2, 6.5, 6.8, 6.9, 7]),
+  'EGIE3': const StockInfo(ticker: 'EGIE3', name: 'Engie Brasil ON', price: 43.00, weeklyReturn: 0.8, monthly: [41, 41.5, 42, 42.5, 42.8, 43]),
+  'NTCO3': const StockInfo(ticker: 'NTCO3', name: 'Natura ON', price: 15.00, weeklyReturn: 1.5, monthly: [13, 13.5, 14, 14.5, 14.8, 15]),
+};
+
+/// Illustrative S&P 500 blue-chip stocks (price in USD), used as the
+/// default watchlist source and offline fallback for the "Ações S&P
+/// 500" screen — mirrors [b3Stocks] but for the American market.
+final Map<String, StockInfo> spStocks = {
+  'AAPL': const StockInfo(ticker: 'AAPL', name: 'Apple Inc.', price: 230.00, weeklyReturn: 1.1, monthly: [190, 200, 210, 205, 220, 230]),
+  'MSFT': const StockInfo(ticker: 'MSFT', name: 'Microsoft Corp.', price: 430.00, weeklyReturn: 0.9, monthly: [370, 385, 395, 400, 415, 430]),
+  'GOOGL': const StockInfo(ticker: 'GOOGL', name: 'Alphabet Inc.', price: 175.00, weeklyReturn: 1.3, monthly: [140, 150, 158, 162, 168, 175]),
+  'AMZN': const StockInfo(ticker: 'AMZN', name: 'Amazon.com Inc.', price: 195.00, weeklyReturn: 1.0, monthly: [160, 168, 175, 180, 188, 195]),
+  'NVDA': const StockInfo(ticker: 'NVDA', name: 'NVIDIA Corp.', price: 140.00, weeklyReturn: 2.4, monthly: [90, 100, 112, 120, 130, 140]),
+  'META': const StockInfo(ticker: 'META', name: 'Meta Platforms Inc.', price: 590.00, weeklyReturn: 1.2, monthly: [480, 500, 520, 540, 565, 590]),
+  'TSLA': const StockInfo(ticker: 'TSLA', name: 'Tesla Inc.', price: 250.00, weeklyReturn: -0.8, monthly: [230, 260, 245, 270, 240, 250]),
+  'BRK-B': const StockInfo(ticker: 'BRK-B', name: 'Berkshire Hathaway Inc.', price: 460.00, weeklyReturn: 0.5, monthly: [420, 430, 440, 445, 452, 460]),
+  'JPM': const StockInfo(ticker: 'JPM', name: 'JPMorgan Chase & Co.', price: 235.00, weeklyReturn: 0.7, monthly: [200, 210, 215, 222, 228, 235]),
+  'JNJ': const StockInfo(ticker: 'JNJ', name: 'Johnson & Johnson', price: 155.00, weeklyReturn: 0.3, monthly: [148, 150, 151, 152, 154, 155]),
+  'V': const StockInfo(ticker: 'V', name: 'Visa Inc.', price: 310.00, weeklyReturn: 0.8, monthly: [275, 285, 292, 298, 304, 310]),
+  'PG': const StockInfo(ticker: 'PG', name: 'Procter & Gamble Co.', price: 170.00, weeklyReturn: 0.2, monthly: [163, 165, 166, 167, 169, 170]),
+  'UNH': const StockInfo(ticker: 'UNH', name: 'UnitedHealth Group Inc.', price: 560.00, weeklyReturn: 0.6, monthly: [520, 530, 540, 545, 552, 560]),
+  'HD': const StockInfo(ticker: 'HD', name: 'Home Depot Inc.', price: 400.00, weeklyReturn: 0.5, monthly: [370, 378, 385, 390, 395, 400]),
+  'MA': const StockInfo(ticker: 'MA', name: 'Mastercard Inc.', price: 500.00, weeklyReturn: 0.9, monthly: [450, 462, 472, 480, 490, 500]),
 };
 
 /// B3 market indices shown alongside the currency/stock watchlist.
@@ -85,6 +106,15 @@ const Map<String, double> indexFallbackPoints = {
   '^BVSP': 136000,
   'IFIX': 3400,
   '^GSPC': 5600,
+};
+
+/// Illustrative offline monthly point history for the market indices,
+/// used by the "Valorização" (appreciation) screen — same spirit as
+/// [currencyHistoryBrl] and each [StockInfo.monthly].
+const Map<String, List<double>> indexHistoryPoints = {
+  '^BVSP': [120000, 125000, 130000, 128000, 133000, 136000],
+  'IFIX': [3100, 3150, 3200, 3250, 3300, 3400],
+  '^GSPC': [5100, 5200, 5300, 5250, 5450, 5600],
 };
 
 /// Percentage change between consecutive entries of a history list.

--- a/app/lib/screens/appreciation_screen.dart
+++ b/app/lib/screens/appreciation_screen.dart
@@ -3,9 +3,12 @@ import 'package:flutter/material.dart';
 
 import '../models/market_data.dart';
 
+enum _Category { currencies, stocks, usStocks, indices }
+
 /// Shows the monthly appreciation percentage (last 6 months) of a
-/// selected currency or B3 stock, based on the illustrative offline
-/// history table (the same data used as fallback elsewhere).
+/// selected currency, B3 stock, S&P 500 stock or market index
+/// (Ibovespa/IFIX/S&P 500), based on the illustrative offline history
+/// table (the same data used as fallback elsewhere).
 class AppreciationScreen extends StatefulWidget {
   const AppreciationScreen({super.key});
 
@@ -14,15 +17,46 @@ class AppreciationScreen extends StatefulWidget {
 }
 
 class _AppreciationScreenState extends State<AppreciationScreen> {
-  bool _showCurrencies = true;
+  _Category _category = _Category.currencies;
   String _selected = 'BTC';
+
+  List<String> _optionsFor(_Category category) {
+    switch (category) {
+      case _Category.currencies:
+        return currencyHistoryBrl.keys.toList();
+      case _Category.stocks:
+        return b3Stocks.keys.toList();
+      case _Category.usStocks:
+        return spStocks.keys.toList();
+      case _Category.indices:
+        return indexLabels.keys.toList();
+    }
+  }
+
+  List<double> _historyFor(_Category category, String selected) {
+    switch (category) {
+      case _Category.currencies:
+        return currencyHistoryBrl[selected]!;
+      case _Category.stocks:
+        return b3Stocks[selected]!.monthly;
+      case _Category.usStocks:
+        return spStocks[selected]!.monthly;
+      case _Category.indices:
+        return indexHistoryPoints[selected]!;
+    }
+  }
+
+  String _labelFor(_Category category, String option) {
+    if (category == _Category.indices) return indexLabels[option]!;
+    return option;
+  }
 
   @override
   Widget build(BuildContext context) {
-    final options = _showCurrencies ? currencyHistoryBrl.keys.toList() : b3Stocks.keys.toList();
+    final options = _optionsFor(_category);
     if (!options.contains(_selected)) _selected = options.first;
 
-    final history = _showCurrencies ? currencyHistoryBrl[_selected]! : b3Stocks[_selected]!.monthly;
+    final history = _historyFor(_category, _selected);
     final appreciation = monthlyAppreciation(history);
 
     return Padding(
@@ -30,19 +64,26 @@ class _AppreciationScreenState extends State<AppreciationScreen> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          SegmentedButton<bool>(
-            segments: const [
-              ButtonSegment(value: true, label: Text('Moedas')),
-              ButtonSegment(value: false, label: Text('Ações B3')),
-            ],
-            selected: {_showCurrencies},
-            onSelectionChanged: (s) => setState(() => _showCurrencies = s.first),
+          SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            child: SegmentedButton<_Category>(
+              segments: const [
+                ButtonSegment(value: _Category.currencies, label: Text('Moedas')),
+                ButtonSegment(value: _Category.stocks, label: Text('Ações B3')),
+                ButtonSegment(value: _Category.usStocks, label: Text('Ações S&P 500')),
+                ButtonSegment(value: _Category.indices, label: Text('Índices')),
+              ],
+              selected: {_category},
+              onSelectionChanged: (s) => setState(() => _category = s.first),
+            ),
           ),
           const SizedBox(height: 16),
           DropdownButtonFormField<String>(
             initialValue: _selected,
             decoration: const InputDecoration(border: OutlineInputBorder(), labelText: 'Selecione'),
-            items: [for (final o in options) DropdownMenuItem(value: o, child: Text(o))],
+            items: [
+              for (final o in options) DropdownMenuItem(value: o, child: Text(_labelFor(_category, o))),
+            ],
             onChanged: (v) => setState(() => _selected = v!),
           ),
           const SizedBox(height: 24),

--- a/app/lib/screens/dashboard_screen.dart
+++ b/app/lib/screens/dashboard_screen.dart
@@ -26,6 +26,7 @@ class _DashboardScreenState extends State<DashboardScreen> {
 
   List<String> _currencies = [];
   List<String> _stocks = [];
+  List<String> _usStocks = [];
   Map<String, double> _currencyPrices = {};
   Map<String, double> _stockPrices = {};
   bool _loading = true;
@@ -48,13 +49,14 @@ class _DashboardScreenState extends State<DashboardScreen> {
   Future<void> _bootstrap() async {
     _currencies = await _watchlist.loadCurrencies();
     _stocks = await _watchlist.loadStocks();
+    _usStocks = await _watchlist.loadUsStocks();
     await _refreshPrices();
   }
 
   Future<void> _refreshPrices() async {
     setState(() => _loading = true);
     final currencyPrices = await _exchange.getAllCurrencyPricesBrl(_currencies);
-    final tickers = [...indexLabels.keys, ..._stocks];
+    final tickers = [...indexLabels.keys, ..._stocks, ..._usStocks];
     final stockPrices = await _b3.getAllPricesBrl(tickers);
     if (!mounted) return;
     setState(() {
@@ -106,6 +108,26 @@ class _DashboardScreenState extends State<DashboardScreen> {
     await _refreshPrices();
   }
 
+  Future<void> _addUsStock() async {
+    final ticker = await _promptForCode(
+      title: 'Adicionar ação americana',
+      hint: 'Ticker (ex: DIS, KO, NFLX)',
+    );
+    if (ticker == null || ticker.isEmpty) return;
+    setState(() => _loading = true);
+    try {
+      await _b3.fetchPriceBrl(ticker.toUpperCase());
+      _usStocks = await _watchlist.addUsStock(ticker);
+    } catch (_) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Ticker inválido ou indisponível.')),
+        );
+      }
+    }
+    await _refreshPrices();
+  }
+
   Future<String?> _promptForCode({required String title, required String hint}) {
     final controller = TextEditingController();
     return showDialog<String>(
@@ -136,6 +158,11 @@ class _DashboardScreenState extends State<DashboardScreen> {
 
   Future<void> _removeStock(String ticker) async {
     _stocks = await _watchlist.removeStock(ticker);
+    setState(() => _stockPrices.remove(ticker));
+  }
+
+  Future<void> _removeUsStock(String ticker) async {
+    _usStocks = await _watchlist.removeUsStock(ticker);
     setState(() => _stockPrices.remove(ticker));
   }
 
@@ -180,13 +207,7 @@ class _DashboardScreenState extends State<DashboardScreen> {
             ),
           Padding(
             padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                Text('Índices e Ações B3', style: Theme.of(context).textTheme.titleMedium),
-                IconButton(icon: const Icon(Icons.add_circle_outline), onPressed: _addStock),
-              ],
-            ),
+            child: Text('Índices', style: Theme.of(context).textTheme.titleMedium),
           ),
           for (final entry in indexLabels.entries)
             PriceTile(
@@ -196,6 +217,16 @@ class _DashboardScreenState extends State<DashboardScreen> {
               loading: _loading && _stockPrices[entry.key] == null,
               currencyPrefix: null,
             ),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text('Ações B3', style: Theme.of(context).textTheme.titleMedium),
+                IconButton(icon: const Icon(Icons.add_circle_outline), onPressed: _addStock),
+              ],
+            ),
+          ),
           for (final ticker in _stocks)
             PriceTile(
               code: ticker,
@@ -203,6 +234,25 @@ class _DashboardScreenState extends State<DashboardScreen> {
               price: _stockPrices[ticker],
               loading: _loading && _stockPrices[ticker] == null,
               onRemove: () => _removeStock(ticker),
+            ),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text('Ações S&P 500', style: Theme.of(context).textTheme.titleMedium),
+                IconButton(icon: const Icon(Icons.add_circle_outline), onPressed: _addUsStock),
+              ],
+            ),
+          ),
+          for (final ticker in _usStocks)
+            PriceTile(
+              code: ticker,
+              label: spStocks[ticker]?.name ?? ticker,
+              price: _stockPrices[ticker],
+              loading: _loading && _stockPrices[ticker] == null,
+              onRemove: () => _removeUsStock(ticker),
+              currencyPrefix: 'US\$ ',
             ),
           const SizedBox(height: 24),
         ],

--- a/app/lib/screens/indices_screen.dart
+++ b/app/lib/screens/indices_screen.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+
+import '../models/market_data.dart';
+import '../services/b3_service.dart';
+
+/// Dedicated screen for the market indices (Ibovespa, IFIX, S&P 500),
+/// shown alongside "Ações B3" in the navigation. Indices are fixed —
+/// unlike stocks/currencies, the user can't add or remove them here.
+class IndicesScreen extends StatefulWidget {
+  const IndicesScreen({super.key});
+
+  @override
+  State<IndicesScreen> createState() => _IndicesScreenState();
+}
+
+class _IndicesScreenState extends State<IndicesScreen> {
+  final _b3 = B3Service();
+  Map<String, double> _prices = {};
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    setState(() => _loading = true);
+    _prices = await _b3.getAllPricesBrl(indexLabels.keys.toList());
+    if (!mounted) return;
+    setState(() => _loading = false);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_loading) return const Center(child: CircularProgressIndicator());
+    return RefreshIndicator(
+      onRefresh: _load,
+      child: ListView(
+        children: [
+          for (final entry in indexLabels.entries)
+            ListTile(
+              leading: CircleAvatar(child: Text(entry.value.characters.first)),
+              title: Text(entry.value),
+              subtitle: Text(
+                _prices[entry.key] == null
+                    ? 'Indisponível'
+                    : '${_prices[entry.key]!.toStringAsFixed(2)} pts',
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/app/lib/screens/sp500_screen.dart
+++ b/app/lib/screens/sp500_screen.dart
@@ -4,16 +4,18 @@ import '../models/market_data.dart';
 import '../services/b3_service.dart';
 import '../services/watchlist_service.dart';
 
-/// Full B3 stock list with live prices and weekly return, plus a
-/// shortcut to add/remove each ticker from the watchlist.
-class B3Screen extends StatefulWidget {
-  const B3Screen({super.key});
+/// S&P 500 blue-chip US stock list with live prices (in USD) and
+/// weekly return, plus a shortcut to add/remove each ticker from the
+/// user's US stocks watchlist. Mirrors [B3Screen] for the American
+/// market.
+class SP500Screen extends StatefulWidget {
+  const SP500Screen({super.key});
 
   @override
-  State<B3Screen> createState() => _B3ScreenState();
+  State<SP500Screen> createState() => _SP500ScreenState();
 }
 
-class _B3ScreenState extends State<B3Screen> {
+class _SP500ScreenState extends State<SP500Screen> {
   final _b3 = B3Service();
   final _watchlist = WatchlistService();
   Map<String, double> _prices = {};
@@ -28,17 +30,17 @@ class _B3ScreenState extends State<B3Screen> {
 
   Future<void> _load() async {
     setState(() => _loading = true);
-    _watched = await _watchlist.loadStocks();
-    _prices = await _b3.getAllPricesBrl(b3Stocks.keys.toList());
+    _watched = await _watchlist.loadUsStocks();
+    _prices = await _b3.getAllPricesBrl(spStocks.keys.toList());
     if (!mounted) return;
     setState(() => _loading = false);
   }
 
   Future<void> _toggle(String ticker) async {
     if (_watched.contains(ticker)) {
-      _watched = await _watchlist.removeStock(ticker);
+      _watched = await _watchlist.removeUsStock(ticker);
     } else {
-      _watched = await _watchlist.addStock(ticker);
+      _watched = await _watchlist.addUsStock(ticker);
     }
     setState(() {});
   }
@@ -50,11 +52,11 @@ class _B3ScreenState extends State<B3Screen> {
       onRefresh: _load,
       child: ListView(
         children: [
-          for (final entry in b3Stocks.entries)
+          for (final entry in spStocks.entries)
             ListTile(
               title: Text('${entry.value.name} (${entry.key})'),
               subtitle: Text(
-                'R\$ ${(_prices[entry.key] ?? entry.value.price).toStringAsFixed(2)} · '
+                'US\$ ${(_prices[entry.key] ?? entry.value.price).toStringAsFixed(2)} · '
                 'Rendimento semanal: ${entry.value.weeklyReturn.toStringAsFixed(2)}%',
               ),
               trailing: IconButton(

--- a/app/lib/services/b3_service.dart
+++ b/app/lib/services/b3_service.dart
@@ -3,8 +3,10 @@ import 'package:http/http.dart' as http;
 
 import '../models/market_data.dart';
 
-/// Fetches B3 stock and market index quotes from brapi.dev, with
-/// offline fallback for known tickers.
+/// Fetches B3 stock, US stock and market index quotes from brapi.dev,
+/// with offline fallback for known tickers. The returned price is in
+/// the ticker's native currency (BRL for B3/indices, USD for US
+/// stocks and the S&P 500) — brapi.dev doesn't convert.
 class B3Service {
   static const _baseUrl = 'https://brapi.dev/api/quote';
 
@@ -43,15 +45,15 @@ class B3Service {
     return (price as num).toDouble();
   }
 
-  /// Latest BRL price for a known B3 [ticker] or market index, falling
+  /// Latest price for a known B3/US [ticker] or market index, falling
   /// back to the offline table on failure. For unknown tickers
   /// (user-added), the live fetch is required and failures propagate.
   Future<double> getPriceBrl(String ticker) async {
     try {
       return await fetchPriceBrl(ticker);
     } catch (_) {
-      final info = b3Stocks[ticker];
-      if (info != null) return info.priceBrl;
+      final info = b3Stocks[ticker] ?? spStocks[ticker];
+      if (info != null) return info.price;
       final indexFallback = indexFallbackPoints[ticker];
       if (indexFallback != null) return indexFallback;
       rethrow;

--- a/app/lib/services/watchlist_service.dart
+++ b/app/lib/services/watchlist_service.dart
@@ -2,68 +2,59 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import '../models/market_data.dart';
 
-/// Persists the user's watchlist (currencies + B3 tickers) in the
-/// browser's localStorage. No account/login is involved — everything is
-/// scoped to the local browser, same spirit as the cookie-based storage
-/// originally requested.
+/// Persists the user's watchlist (currencies, B3 tickers and US
+/// stocks) in the browser's localStorage. No account/login is
+/// involved — everything is scoped to the local browser, same spirit
+/// as the cookie-based storage originally requested.
 class WatchlistService {
   static const _currenciesKey = 'watchlist_currencies';
   static const _stocksKey = 'watchlist_stocks';
+  static const _usStocksKey = 'watchlist_us_stocks';
 
   static const defaultCurrencies = ['USD', 'BTC', 'ETH', 'BNB', 'SUI', 'PAXG'];
   static const defaultStocks = ['PETR4', 'VALE3', 'ITUB4', 'BBAS3', 'WEGE3'];
+  static const defaultUsStocks = ['AAPL', 'MSFT', 'GOOGL', 'AMZN', 'NVDA'];
 
-  Future<List<String>> loadCurrencies() async {
+  Future<List<String>> _load(String key, List<String> fallback) async {
     final prefs = await SharedPreferences.getInstance();
-    return prefs.getStringList(_currenciesKey) ?? List.of(defaultCurrencies);
+    return prefs.getStringList(key) ?? List.of(fallback);
   }
 
-  Future<List<String>> loadStocks() async {
+  Future<void> _save(String key, List<String> values) async {
     final prefs = await SharedPreferences.getInstance();
-    return prefs.getStringList(_stocksKey) ?? List.of(defaultStocks);
+    await prefs.setStringList(key, values);
   }
 
-  Future<void> saveCurrencies(List<String> codes) async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setStringList(_currenciesKey, codes);
-  }
-
-  Future<void> saveStocks(List<String> tickers) async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setStringList(_stocksKey, tickers);
-  }
-
-  Future<List<String>> addCurrency(String code) async {
-    final list = await loadCurrencies();
-    final normalized = code.trim().toUpperCase();
+  Future<List<String>> _add(String key, List<String> fallback, String value) async {
+    final list = await _load(key, fallback);
+    final normalized = value.trim().toUpperCase();
     if (normalized.isEmpty || list.contains(normalized)) return list;
     list.add(normalized);
-    await saveCurrencies(list);
+    await _save(key, list);
     return list;
   }
 
-  Future<List<String>> removeCurrency(String code) async {
-    final list = await loadCurrencies();
-    list.remove(code);
-    await saveCurrencies(list);
+  Future<List<String>> _remove(String key, List<String> fallback, String value) async {
+    final list = await _load(key, fallback);
+    list.remove(value);
+    await _save(key, list);
     return list;
   }
 
-  Future<List<String>> addStock(String ticker) async {
-    final list = await loadStocks();
-    final normalized = ticker.trim().toUpperCase();
-    if (normalized.isEmpty || list.contains(normalized)) return list;
-    list.add(normalized);
-    await saveStocks(list);
-    return list;
-  }
+  Future<List<String>> loadCurrencies() => _load(_currenciesKey, defaultCurrencies);
+  Future<void> saveCurrencies(List<String> codes) => _save(_currenciesKey, codes);
+  Future<List<String>> addCurrency(String code) => _add(_currenciesKey, defaultCurrencies, code);
+  Future<List<String>> removeCurrency(String code) => _remove(_currenciesKey, defaultCurrencies, code);
 
-  Future<List<String>> removeStock(String ticker) async {
-    final list = await loadStocks();
-    list.remove(ticker);
-    await saveStocks(list);
-    return list;
-  }
+  Future<List<String>> loadStocks() => _load(_stocksKey, defaultStocks);
+  Future<void> saveStocks(List<String> tickers) => _save(_stocksKey, tickers);
+  Future<List<String>> addStock(String ticker) => _add(_stocksKey, defaultStocks, ticker);
+  Future<List<String>> removeStock(String ticker) => _remove(_stocksKey, defaultStocks, ticker);
+
+  Future<List<String>> loadUsStocks() => _load(_usStocksKey, defaultUsStocks);
+  Future<void> saveUsStocks(List<String> tickers) => _save(_usStocksKey, tickers);
+  Future<List<String>> addUsStock(String ticker) => _add(_usStocksKey, defaultUsStocks, ticker);
+  Future<List<String>> removeUsStock(String ticker) => _remove(_usStocksKey, defaultUsStocks, ticker);
 
   /// Human-readable label for a currency code, falling back to the code
   /// itself for user-added currencies not in the known list.


### PR DESCRIPTION
## Summary
- Splits market indices (Ibovespa, IFIX, S&P 500) into their own **Índices** nav item/screen, separate from the "Ações B3" section they used to share on the dashboard.
- Adds a new **Ações S&P 500** screen mirroring "Ações B3", with a basket of 15 US blue chips (AAPL, MSFT, GOOGL, AMZN, NVDA, META, TSLA, BRK-B, JPM, JNJ, V, PG, UNH, HD, MA), live-priced via brapi.dev (which also serves US tickers, not just B3).
- Dashboard now shows 4 distinct sections: Moedas, Índices, Ações B3, Ações S&P 500 — each with its own watchlist persisted independently in localStorage.
- Valorização (appreciation) screen gained a 4th category (besides Moedas/Ações B3/Índices) so monthly history works for US stocks too.
- Renamed `StockInfo.priceBrl` → `price` since the same model is now reused for USD-denominated US stocks, not just BRL-denominated B3 stocks.

## Test plan
- [x] `flutter analyze` — no issues
- [x] `flutter test` — all tests passing
- [x] Verified live via a standalone `dart run` script: all 15 S&P 500 tickers resolved with real prices
- [x] `flutter build web --release` — builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)